### PR TITLE
Tick count

### DIFF
--- a/src/rtu/mbutils.c
+++ b/src/rtu/mbutils.c
@@ -102,4 +102,4 @@ uint16_t mbus_crc16(const uint16_t crc16, const uint8_t byte) {
   return (aucCRCLo[index] << 8) | ((crc16 >> 8) ^ aucCRCHi[index]);
 }
 
-uint32_t mbus_tickcount() { return 0; }
+__attribute__((weak)) uint32_t mbus_tickcount() { return 0; }


### PR DESCRIPTION
Available to override custom function mbus_tickcount () with real tick counter implementation

in main.c
```
uint32_t sysTick = 0;

uint32_t mbus_tickcount() {
	return sysTick;
}
```